### PR TITLE
fix: extra slash from package.json repository url

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   ],
   "repository": {
     "type": "git",
-    "url": "https://github.com/InfiniteXyy//zustand-computed-middleware"
+    "url": "https://github.com/InfiniteXyy/zustand-computed-middleware"
   },
   "files": [
     "dist",


### PR DESCRIPTION
Noticed this when I was browsing on npm. Thanks!